### PR TITLE
Audit trail

### DIFF
--- a/app/dashboard/projects/[id]/audit/page.tsx
+++ b/app/dashboard/projects/[id]/audit/page.tsx
@@ -11,34 +11,35 @@ export default async function Page(props: { params: Promise<{id: string}>}) {
         return <div>Error loading audit history</div>;
     }
     
+    
     return (
     <div>
         <h2>Audit History for <em><Link className="text-blue-500 hover:text-blue-700 hover:underline" href={`/dashboard/projects/${id}`}>{project.project_name}</Link></em></h2>
         <p>Audit history is a record of all changes made to the project. It is useful for tracking changes and for debugging.</p>
         
-        <div className='flex flex-col gap-2 bg-gray-200 p-2 rounded-md'>
+        <div className='flex flex-col gap-2 p-2'>
         {audit.length == 0 ? (
                     <p>No audit history found</p>
                 ) : (
                     
                     audit.map((record: any) => (
                         
-                    <div className='flex flex-col gap-2 bg-gray-100 p-2 rounded-md' key={record.audit_id}>
-                        <div className='flex flex-row gap-2'>
+                    <div className='flex flex-col px-[.2rem] pt-[.4rem] pb-0; bg-white border-[.1rem] border-solid border-[#bfbfbf] border-l-[0.5rem]' key={record.audit_id}>
+                        <div className='flex flex-row gap-2 border-b-[.1rem] border-dashed border-[#bfbfbf]'>
                             <p>Changed by: <strong>{record.name}</strong></p>
                             <p>Changed at: <strong>{new Date(record.timestamp).toLocaleString()}</strong></p>
                         </div>
                         <p><strong>Fields affected:</strong><br /> {JSON.stringify((JSON.parse(record.data).fields_affected), null, 2)}</p>
-                        <div className='flex flex-row justify-between gap-2'>
+                        <div className='flex flex-row justify-between gap-[0.2rem]'>
                             <div className='w-1/2'>
                                 <p><strong>Old values:</strong></p>
-                                <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
-                                    value={JSON.stringify((JSON.parse(record.data).old_value), null, 2)}>
+                                <textarea className='w-full h-32 p-[0.2rem] border-[.05rem] border-solid border-[#bfbfbf] text-xs' readOnly
+                                    value={JSON.stringify((JSON.parse(record.data).previous_value), null, 2)}>
                                 </textarea>
                             </div>
                             <div className='w-1/2'>
                             <p><strong>New values:</strong></p>
-                            <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                            <textarea className='w-full h-32 p-[0.2rem] border-[.05rem] border-solid border-[#bfbfbf] text-xs' readOnly
                                 value={JSON.stringify((JSON.parse(record.data).new_value), null, 2)}>
                             </textarea>
                             </div>

--- a/app/dashboard/projects/[id]/audit/page.tsx
+++ b/app/dashboard/projects/[id]/audit/page.tsx
@@ -1,0 +1,95 @@
+import { fetchProjectById } from '@/app/lib/data';
+import { fetchAudit } from '@/app/lib/fetchdb/fetch-audit';
+import Link from 'next/link';
+export default async function Page(props: { params: Promise<{id: string}>}) {
+    const params = await props.params;
+    const id = params.id;
+    
+    const project = await fetchProjectById(id);
+    const audit = await fetchAudit(id);
+    if (audit instanceof Error) {
+        return <div>Error loading audit history</div>;
+    }
+    
+    return (
+    <div>
+        <h2>Audit History for <em><Link className="text-blue-500 hover:text-blue-700 hover:underline" href={`/dashboard/projects/${id}`}>{project.project_name}</Link></em></h2>
+        <p>Audit history is a record of all changes made to the project. It is useful for tracking changes and for debugging.</p>
+        
+        <div className='flex flex-col gap-2 bg-gray-200 p-2 rounded-md'>
+        {audit.length == 0 ? (
+                    <p>No audit history found</p>
+                ) : (
+                    
+                    audit.map((record: any) => (
+                        
+                    <div className='flex flex-col gap-2 bg-gray-100 p-2 rounded-md' key={record.audit_id}>
+                        <div className='flex flex-row gap-2'>
+                            <p>Changed by: <strong>{record.name}</strong></p>
+                            <p>Changed at: <strong>{new Date(record.timestamp).toLocaleString()}</strong></p>
+                        </div>
+                        <p><strong>Fields affected:</strong><br /> {JSON.stringify((JSON.parse(record.data).fields_affected), null, 2)}</p>
+                        <div className='flex flex-row justify-between gap-2'>
+                            <div className='w-1/2'>
+                                <p><strong>Old values:</strong></p>
+                                <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                                    value={JSON.stringify((JSON.parse(record.data).old_value), null, 2)}>
+                                </textarea>
+                            </div>
+                            <div className='w-1/2'>
+                            <p><strong>New values:</strong></p>
+                            <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                                value={JSON.stringify((JSON.parse(record.data).new_value), null, 2)}>
+                            </textarea>
+                            </div>
+                        </div>
+                    </div>
+
+            ))
+            )}
+            </div>
+        
+        <hr />
+        {/* <table>
+            <thead>
+                <tr>
+                    <th>User</th>
+                    <th>Date</th>
+                    <th>Fields Affected</th>
+                    <th>Old Value</th>
+                    <th>New Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {audit.length == 0 ? (
+                    <tr>
+                        <td colSpan={5}>No audit history found</td>
+                    </tr>
+                ) : (
+                    audit.map((record: any) => (
+                        <tr key={record.audit_id}>
+                        <td>{record.name}</td>
+                        <td>{new Date(record.timestamp).toLocaleString()}</td>
+                        <td>
+                            <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                                value={JSON.stringify((JSON.parse(record.data).fields_affected), null, 2)}>
+                            </textarea>
+                            </td>
+                        <td>
+                            <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                                value={JSON.stringify((JSON.parse(record.data).old_value), null, 2)}>
+                            </textarea>
+                        </td>
+                        <td>
+                            <textarea className='w-full h-24 bg-gray-100 p-2 rounded-md' readOnly
+                                value={JSON.stringify((JSON.parse(record.data).new_value), null, 2)}>
+                            </textarea>
+                        </td>
+                        
+                    </tr>
+                )))}
+            </tbody>
+        </table> */}
+    </div>
+)
+}

--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -69,6 +69,11 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
                             Edit Project
                         </Link>
                         <DeleteProjectButton projectId={id}/>
+                        <Link href={`/dashboard/projects/${id}/audit`}>
+                            <Button className="bg-gray-800 hover:bg-gray-600 hover:text-white">
+                                Audit History
+                            </Button>
+                        </Link>
                     </div>
 
                 </div>

--- a/app/dashboard/projects/create/page.tsx
+++ b/app/dashboard/projects/create/page.tsx
@@ -1,12 +1,15 @@
 import CreateProjectForm from "@/app/ui/projects/create-project";
 import Link   from "next/link";
 import { Button } from "@/app/ui/button";
+import { activeSession } from "@/app/lib/utils/activeSession";
 
-export default function Page() {
+export default async function Page() {
+  const session = await activeSession();
+
     return (
         <div>
             <h1>Create Project</h1>
-            <CreateProjectForm />
+            <CreateProjectForm session={session} />
             <Link href="/dashboard/projects">
       <Button>
         Back to Projects

--- a/app/dashboard/projects/edit/[id]/page.tsx
+++ b/app/dashboard/projects/edit/[id]/page.tsx
@@ -3,11 +3,14 @@ import EditProjectForm from "@/app/ui/projects/edit-project";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Button } from "@/app/ui/button";
+import { activeSession } from "@/app/lib/utils/activeSession";
 
 export default async function Page(props: { params: Promise<{ id: string }>}) {
     const params = await props.params;
     const id = params.id;
     const project = await fetchProjectById(id); // Fetch the project
+    const session = await activeSession();
+
 
   if (!project) {
     notFound(); // Show a 404 page if the project is not found
@@ -16,7 +19,7 @@ export default async function Page(props: { params: Promise<{ id: string }>}) {
   return (
     <div>
       <h1>DEVELOPMENT Edit Project</h1>
-      <EditProjectForm project={project} />
+      <EditProjectForm project={project} session={session} />
       <br />
       <Link href="/dashboard/projects">
       <Button>

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -1,6 +1,19 @@
 // This file contains type definitions for your data.
 // It describes the shape of the data, and what data type each property should accept.
 
+export type AuditData= {
+    project_id: string,
+    previous_value: string[],
+    new_value: string[],
+    fields_affected: string[],
+}
+
+export type AuditRecord = {
+    user_id: string,
+    project_id: string,
+    data: string,
+}
+
 export type User = {
     id: string;
     name: string;

--- a/app/lib/fetchdb/fetch-audit.ts
+++ b/app/lib/fetchdb/fetch-audit.ts
@@ -1,0 +1,13 @@
+import postgres from "postgres";
+
+const sql = postgres(process.env.POSTGRES_URL!, {ssl: 'require'});
+
+export async function fetchAudit(project_id: string) {
+    try {
+        const data = await sql`SELECT a.*, u.name FROM audits a JOIN users u ON a.user_id = u.id WHERE a.project_id = ${project_id}`;
+        return data;
+    } catch (error) {
+        console.error('Database Error:', error);
+        return new Error('Database Error');
+    }
+}

--- a/app/lib/writedb/write-audit.ts
+++ b/app/lib/writedb/write-audit.ts
@@ -1,0 +1,23 @@
+import postgres from "postgres";
+import { AuditData, AuditRecord } from "@/app/lib/definitions";
+
+const sql = postgres(process.env.POSTGRES_URL!, {ssl: 'require'});
+
+export async function writeAudit(auditData: AuditRecord) {
+    // //     project_id: string,
+    // previous_value: string[],
+    // new_value: string[],
+    // fields_affected: string[], *//
+    const project_id = auditData.project_id;
+    const user_id = auditData.user_id;
+    const data = auditData.data;
+
+    try {
+        await sql`INSERT INTO audits (project_id, user_id, data) VALUES (${project_id}, ${user_id}, ${JSON.stringify(data)})`;
+    } catch (error) {
+        console.error('Error writing audit record:', error);
+        throw error;
+    }
+}
+
+

--- a/app/lib/writedb/write-audit.ts
+++ b/app/lib/writedb/write-audit.ts
@@ -3,7 +3,7 @@ import { AuditData, AuditRecord } from "@/app/lib/definitions";
 
 const sql = postgres(process.env.POSTGRES_URL!, {ssl: 'require'});
 
-export async function writeAudit(sqlResult: any, user_id: string) {
+export async function writeAudit(sqlResult: any, user_id: string, prev_value?: any) {
     // Write Audit Record
 
     // Get fields affected
@@ -12,6 +12,8 @@ export async function writeAudit(sqlResult: any, user_id: string) {
       fields_affected.push(key);
     }
 
+    // Get old value
+    console.log('prev_value:',prev_value);
 
     // Get Project ID if exitsts
     let project_id;
@@ -23,7 +25,7 @@ export async function writeAudit(sqlResult: any, user_id: string) {
 
     const auditData: AuditData = {
         project_id: sqlResult[0].project_id,
-        previous_value: ['nil'],
+        previous_value: prev_value,
         new_value: sqlResult,
         fields_affected: fields_affected
     }

--- a/app/ui/projects/create-project.tsx
+++ b/app/ui/projects/create-project.tsx
@@ -27,8 +27,10 @@ const PROJECT_STATUS_OPTIONS = [
   'Completed'
 ];
 
-export default function CreateProjectForm() {
+
+export default function CreateProjectForm(session: any) {
   const router = useRouter();
+
   const [formData, setFormData] = useState({
     project_name: '',
     asx_code: '',
@@ -39,10 +41,12 @@ export default function CreateProjectForm() {
     product: '',
     project_status: 'Publicly announced'
   });
+  const user_session = session;
+  console.log(user_session.session.name);
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await createProject(formData);
+    e.preventDefault();     
+    await createProject(formData, user_session.session.id);
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {

--- a/app/ui/projects/edit-project.tsx
+++ b/app/ui/projects/edit-project.tsx
@@ -27,7 +27,7 @@ const PROJECT_STATUS_OPTIONS = [
   'Completed'
 ];
 
-export default function EditProjectForm({ project }: { project: any }) {
+export default function EditProjectForm({ project, session }: { project: any, session: any }) {
   const router = useRouter();
   const [formData, setFormData] = useState({
     project_id: '',
@@ -41,6 +41,8 @@ export default function EditProjectForm({ project }: { project: any }) {
     project_status: 'Publicly announced'
   });
 
+  const user_session = session;
+  console.log(user_session.id);
   useEffect(() => {
     if (project) {
       setFormData({
@@ -62,7 +64,7 @@ export default function EditProjectForm({ project }: { project: any }) {
     e.preventDefault();
     try {
       console.log("Running function updateProject");
-      await updateProject(formData);
+      await updateProject(formData, user_session.id);
       console.log("Redirect");
       router.push(`/dashboard/projects/${project.project_id}`);
     } catch (error) {


### PR DESCRIPTION
Added basic audit logging of creating new projects, and editing the top level information on a project. Also can view all the edits of a project in the Audit page from button.

Theres a new function in `lib/write-audit.ts` called writeAudit, which takes as a minimum the SQL result of the change, and the user_id as a string. Third parameter is the SQL result of the pervious state, before the change.

The create project and update project functions and forms have been edited to take the user session.